### PR TITLE
Updated graylog to a version that can print error messages.

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "author": "Sayan Bhattacharya <bhattacharyasayan.21@gmail.com>",
   "license": "ISC",
   "dependencies": {
-    "graylog2": "0.2.1",
+    "graylog2": "git@github.com:Wizcorp/node-graylog2.git#817cd0d",
     "winston": "3.2.1"
   }
 }


### PR DESCRIPTION
Fetching from github coz the new commit into master has not been released by git@github.com:Wizcorp/node-graylog2.git yet